### PR TITLE
fix: restore answer type from cache as enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,8 +214,10 @@ export type ResolveDnsProgressEvents =
   ProgressEvent<'dns:response', DNSResponse> |
   ProgressEvent<'dns:error', Error>
 
+export type DNSResolvers = Record<string, DNSResolver | DNSResolver[]>
+
 export interface DNSInit {
-  resolvers?: Record<string, DNSResolver | DNSResolver[]>
+  resolvers?: DNSResolvers
 }
 
 export function dns (init: DNSInit = {}): DNS {

--- a/src/resolvers/default.ts
+++ b/src/resolvers/default.ts
@@ -1,14 +1,16 @@
 import { Resolver } from 'dns/promises'
 import { RecordType } from '../index.js'
+import { getTypes } from '../utils/get-types.js'
 import { toDNSResponse } from '../utils/to-dns-response.js'
 import type { DNSResolver } from './index.js'
 import type { Answer } from '../index.js'
 
-const nodeResolver: DNSResolver = async (fqdn, types, options = {}) => {
+const nodeResolver: DNSResolver = async (fqdn, options = {}) => {
   const resolver = new Resolver()
   const listener = (): void => {
     resolver.cancel()
   }
+  const types = getTypes(options.types)
 
   try {
     options.signal?.addEventListener('abort', listener)

--- a/src/resolvers/dns-json-over-https.ts
+++ b/src/resolvers/dns-json-over-https.ts
@@ -2,6 +2,7 @@
 
 import PQueue from 'p-queue'
 import { CustomProgressEvent } from 'progress-events'
+import { getTypes } from '../utils/get-types.js'
 import { toDNSResponse } from '../utils/to-dns-response.js'
 import type { DNSResolver } from './index.js'
 import type { DNSResponse } from '../index.js'
@@ -37,11 +38,11 @@ export function dnsJsonOverHttps (url: string, init: DNSJSONOverHTTPSOptions = {
     concurrency: init.queryConcurrency ?? DEFAULT_QUERY_CONCURRENCY
   })
 
-  return async (fqdn, types, options = {}) => {
+  return async (fqdn, options = {}) => {
     const searchParams = new URLSearchParams()
     searchParams.set('name', fqdn)
 
-    types.forEach(type => {
+    getTypes(options.types).forEach(type => {
       searchParams.append('type', type.toString())
     })
 

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,7 +1,7 @@
-import type { DNSResponse, QueryOptions, RecordType } from '../index.js'
+import type { DNSResponse, QueryOptions } from '../index.js'
 
 export interface DNSResolver {
-  (domain: string, types: RecordType[], options?: QueryOptions): Promise<DNSResponse>
+  (domain: string, options?: QueryOptions): Promise<DNSResponse>
 }
 
 export { dnsOverHttps } from './dns-over-https.js'

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,6 +1,7 @@
 import hashlru from 'hashlru'
+import { RecordType } from '../index.js'
 import { DEFAULT_TTL, toDNSResponse } from './to-dns-response.js'
-import type { Answer, DNSResponse, RecordType } from '../index.js'
+import type { Answer, DNSResponse } from '../index.js'
 
 interface CachedAnswer {
   expires: number
@@ -48,12 +49,17 @@ export class AnswerCache {
         .filter((entry) => {
           return entry.expires > Date.now()
         })
-        .map(({ value }) => value)
+        .map(({ value }) => ({
+          ...value,
+          type: RecordType[value.type]
+        }))
 
       if (cachedAnswers.length === 0) {
         this.lru.remove(key)
       }
 
+      // @ts-expect-error hashlru stringifies stored types which turns enums
+      // into strings, we convert back into enums above but tsc doesn't know
       return cachedAnswers
     }
 

--- a/src/utils/get-types.ts
+++ b/src/utils/get-types.ts
@@ -1,0 +1,23 @@
+import { RecordType } from '../index.js'
+
+export function getTypes (types?: RecordType | RecordType[]): RecordType[] {
+  const DEFAULT_TYPES = [
+    RecordType.A
+  ]
+
+  if (types == null) {
+    return DEFAULT_TYPES
+  }
+
+  if (Array.isArray(types)) {
+    if (types.length === 0) {
+      return DEFAULT_TYPES
+    }
+
+    return types
+  }
+
+  return [
+    types
+  ]
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -107,4 +107,37 @@ describe('dns', () => {
 
     expect(defaultResolver.callCount).to.equal(4)
   })
+
+  it('should return enums from cache', async () => {
+    const defaultResolver = Sinon.stub()
+
+    const answerA = {
+      name: 'example-enum-cache.com',
+      data: '123.123.123.123',
+      type: RecordType.A
+    }
+    const answerAAAA = {
+      name: 'example-enum-cache.com',
+      data: ':::1',
+      type: RecordType.AAAA
+    }
+
+    defaultResolver.withArgs('example-enum-cache.com').resolves({
+      Answer: [answerA, answerAAAA]
+    })
+
+    const resolver = dns({
+      resolvers: {
+        '.': defaultResolver
+      }
+    })
+
+    const res1 = await resolver.query('example-enum-cache.com')
+    expect(res1).to.have.nested.property('Answer[0].type', RecordType.A)
+
+    const res2 = await resolver.query('example-enum-cache.com')
+    expect(res2).to.have.nested.property('Answer[0].type', RecordType.A)
+
+    expect(defaultResolver.callCount).to.equal(1)
+  })
 })

--- a/test/resolvers/dns-json-over-https.spec.ts
+++ b/test/resolvers/dns-json-over-https.spec.ts
@@ -5,7 +5,9 @@ import { dnsJsonOverHttps } from '../../src/resolvers/dns-json-over-https.js'
 describe('dns-json-over-https', () => {
   it('should query dns', async () => {
     const resolver = dnsJsonOverHttps('https://cloudflare-dns.com/dns-query')
-    const result = await resolver('google.com', [RecordType.A])
+    const result = await resolver('google.com', {
+      types: [RecordType.A]
+    })
 
     expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
   })

--- a/test/resolvers/dns-over-https.spec.ts
+++ b/test/resolvers/dns-over-https.spec.ts
@@ -5,7 +5,9 @@ import { dnsOverHttps } from '../../src/resolvers/dns-over-https.js'
 describe('dns-over-https', () => {
   it('should query dns', async () => {
     const resolver = dnsOverHttps('https://cloudflare-dns.com/dns-query')
-    const result = await resolver('google.com', [RecordType.A])
+    const result = await resolver('google.com', {
+      types: [RecordType.A]
+    })
 
     expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
   })


### PR DESCRIPTION
The hashlru module serializes/deserializes values when storing them which turns enums into strings, so turn strings back into enums when returning cached results.