### PR TITLE
fix: use per-instance caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ const resolver = dns({
     // will only be used to resolve `.com` addresses
     'com.': dnsJsonOverHttps('https://cloudflare-dns.com/dns-query'),
 
-    // this can also be an array, resolvers will be tried in series
+    // this can also be an array, resolvers will be shuffled and tried in
+    // series
     'net.': [
       dnsJsonOverHttps('https://dns.google/resolve'),
       dnsJsonOverHttps('https://dns.pub/dns-query')
@@ -70,17 +71,13 @@ import { dns, RecordType } from '@multiformats/dns'
 
 const resolver = dns()
 
-// resolve TXT records
+// resolve only TXT records
 const result = await dns.query('google.com', {
   types: [
     RecordType.TXT
   ]
 })
 ```
-
-N.b if multiple record types are specified, most resolvers will throw if answers
-are not available for all of them, so if you consider some record types optional
-it's better to make multiple queries.
 
 ## Caching
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@
  *
  * const resolver = dns()
  *
- * // resolve A and AAAA records with a 5s timeout
+ * // resolve A records with a 5s timeout
  * const result = await dns.query('google.com', {
  *   signal: AbortSignal.timeout(5000)
  * })
@@ -217,7 +217,44 @@ export type ResolveDnsProgressEvents =
 export type DNSResolvers = Record<string, DNSResolver | DNSResolver[]>
 
 export interface DNSInit {
+  /**
+   * A set of resolvers used to answer DNS queries
+   *
+   * String keys control which resolvers are used for which TLDs.
+   *
+   * @example
+   *
+   * ```TypeScript
+   * import { dns } from '@multiformats/dns'
+   * import { dnsOverHttps } from '@multiformats/dns'
+   *
+   * const resolver = dns({
+   *   resolvers: {
+   *     // only used for .com domains
+   *     'com.': dnsOverHttps('https://example-1.com'),
+   *
+   *     // only used for .net domains, can be an array
+   *     'net.': [
+   *       dnsOverHttps('https://example-2.com'),
+   *       dnsOverHttps('https://example-3.com'),
+   *     ],
+   *
+   *     // used for everything else (can be an array)
+   *     '.': dnsOverHttps('https://example-4.com')
+   *   }
+   * })
+   * ```
+   */
   resolvers?: DNSResolvers
+
+  /**
+   * To avoid repeating DNS lookups, successful answers are cached according to
+   * their TTL. To avoid exhausting memory, this option controls how many
+   * answers to cache.
+   *
+   * @default 1000
+   */
+  cacheSize?: number
 }
 
 export function dns (init: DNSInit = {}): DNS {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -8,12 +8,19 @@ interface CachedAnswer {
   value: Answer
 }
 
+export interface AnswerCache {
+  get (fqdn: string, types: RecordType[]): DNSResponse | undefined
+  add (domain: string, answer: Answer): void
+  remove (domain: string, type: ResponseType): void
+  clear (): void
+}
+
 /**
  * Time Aware Least Recent Used Cache
  *
  * @see https://arxiv.org/pdf/1801.00390
  */
-export class AnswerCache {
+class CachedAnswers {
   private readonly lru: ReturnType<typeof hashlru>
 
   constructor (maxSize: number) {
@@ -92,4 +99,6 @@ export class AnswerCache {
 /**
  * Avoid sending multiple queries for the same hostname by caching results
  */
-export const cache = new AnswerCache(1000)
+export function cache (size: number): AnswerCache {
+  return new CachedAnswers(size)
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -69,6 +69,37 @@ describe('dns', () => {
     expect(defaultResolver.calledOnce).to.be.true()
   })
 
+  it('should use separate caches', async () => {
+    const defaultResolver = Sinon.stub()
+
+    const answerA = {
+      name: 'another.com',
+      data: '123.123.123.123',
+      type: RecordType.A
+    }
+
+    defaultResolver.withArgs('another.com').resolves({
+      Answer: [answerA]
+    })
+
+    const resolverA = dns({
+      resolvers: {
+        '.': defaultResolver
+      }
+    })
+    const resolverB = dns({
+      resolvers: {
+        '.': defaultResolver
+      }
+    })
+    await resolverA.query('another.com')
+    await resolverA.query('another.com')
+    await resolverB.query('another.com')
+    await resolverB.query('another.com')
+
+    expect(defaultResolver.calledTwice).to.be.true()
+  })
+
   it('should ignore cache results', async () => {
     const defaultResolver = Sinon.stub()
 


### PR DESCRIPTION
To remove side effects and prevent one dns instance poisoning the cache of another, use per-instance answer caching.