### PR TITLE
fix: update TTL of cached results

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -56,8 +56,9 @@ class CachedAnswers {
         .filter((entry) => {
           return entry.expires > Date.now()
         })
-        .map(({ value }) => ({
+        .map(({ expires, value }) => ({
           ...value,
+          TTL: Math.round((expires - Date.now()) / 1000),
           type: RecordType[value.type]
         }))
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'aegir/chai'
 import Sinon from 'sinon'
 import { RecordType, dns } from '../src/index.js'
-import type { Answer } from '@multiformats/dns'
+import type { Answer } from '../src/index.js'
 
 describe('dns', () => {
   it('should query dns', async () => {


### PR DESCRIPTION
To allow downstream users to know when a cached result will drop out of the cache, update the TTL of returned cached results to reflect time passing since the answer was cached.