### PR TITLE
feat: allow querying with RecordType labels

### DIFF
--- a/src/dns.ts
+++ b/src/dns.ts
@@ -52,7 +52,10 @@ export class DNS implements DNSInterface {
 
     if (cached != null) {
       options.onProgress?.(new CustomProgressEvent<string>('dns:cache', { detail: cached }))
-
+      cached.Answer = cached.Answer.map((answer) => {
+        answer.type = convertType(answer.type, options.useRecordTypeValue)
+        return answer
+      })
       return cached
     }
 

--- a/src/dns.ts
+++ b/src/dns.ts
@@ -1,7 +1,7 @@
 import { CustomProgressEvent } from 'progress-events'
 import { defaultResolver } from './resolvers/default.js'
 import { cache } from './utils/cache.js'
-import { getTypes } from './utils/get-types.js'
+import { convertType, getTypes } from './utils/get-types.js'
 import type { DNS as DNSInterface, DNSInit, DNSResponse, QueryOptions } from './index.js'
 import type { DNSResolver } from './resolvers/index.js'
 import type { AnswerCache } from './utils/cache.js'
@@ -74,6 +74,14 @@ export class DNS implements DNSInterface {
           ...options,
           types
         })
+
+        result.Answer = result.Answer
+          .map((answer) => {
+            // convert type to either RecordType or RecordTypeLabel
+            answer.type = convertType(answer.type, options.useRecordTypeValue)
+
+            return answer
+          })
 
         for (const answer of result.Answer) {
           this.cache.add(domain, answer)

--- a/src/dns.ts
+++ b/src/dns.ts
@@ -11,10 +11,12 @@ const DEFAULT_ANSWER_CACHE_SIZE = 1000
 export class DNS implements DNSInterface {
   private readonly resolvers: Record<string, DNSResolver[]>
   private readonly cache: AnswerCache
+  private readonly useRecordTypeValue: boolean
 
   constructor (init: DNSInit) {
     this.resolvers = {}
     this.cache = cache(init.cacheSize ?? DEFAULT_ANSWER_CACHE_SIZE)
+    this.useRecordTypeValue = init.useRecordTypeValue ?? true
 
     Object.entries(init.resolvers ?? {}).forEach(([tld, resolver]) => {
       if (!Array.isArray(resolver)) {
@@ -44,7 +46,8 @@ export class DNS implements DNSInterface {
    * Any new responses will be added to the cache for subsequent requests.
    */
   async query (domain: string, options: QueryOptions = {}): Promise<DNSResponse> {
-    const types = getTypes(options.types)
+    options.useRecordTypeValue = options.useRecordTypeValue ?? this.useRecordTypeValue
+    const types = getTypes(options.types, options.useRecordTypeValue)
     const cached = options.cached !== false ? this.cache.get(domain, types) : undefined
 
     if (cached != null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,7 @@ export interface QueryOptions extends ProgressOptions<ResolveDnsProgressEvents> 
   types?: RecordType | RecordTypeLabel | Array<RecordType | RecordTypeLabel>
 
   /**
-   * Whether to use the value or string label of the record type
+   * Whether to use the value or string label of the record type when passing queries to the resolver
    *
    * Note that for DNS-over-HTTPS, this is always `false` because the npm package
    * `dns-packet` only supports string label record types for the `encode` method.

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,13 @@ export enum RecordType {
   AAAA = 28
 }
 
+export enum RecordTypeLabel {
+  A = 'A',
+  CNAME = 'CNAME',
+  TXT = 'TXT',
+  AAAA = 'AAAA'
+}
+
 export interface Question {
   /**
    * The record name requested.
@@ -107,7 +114,7 @@ export interface Question {
    *
    * @see https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4.
    */
-  type: RecordType
+  type: RecordType | RecordTypeLabel
 }
 
 export interface Answer {
@@ -121,7 +128,7 @@ export interface Answer {
    *
    * @see https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
    */
-  type: RecordType
+  type: RecordType | RecordTypeLabel
 
   /**
    * The number of seconds the answer can be stored in cache before it is
@@ -201,7 +208,14 @@ export interface QueryOptions extends ProgressOptions<ResolveDnsProgressEvents> 
    *
    * @default [RecordType.A, RecordType.AAAA]
    */
-  types?: RecordType | RecordType[]
+  types?: RecordType | RecordTypeLabel | Array<RecordType | RecordTypeLabel>
+
+  /**
+   * Whether to use the value or string label of the record type
+   *
+   * @default {true}
+   */
+  useRecordTypeValue?: boolean
 }
 
 export interface DNS {
@@ -255,6 +269,15 @@ export interface DNSInit {
    * @default 1000
    */
   cacheSize?: number
+
+  /**
+   * Whether to use the value or string label of the record type when passing queries to the resolver
+   *
+   * @see https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4.
+   *
+   * @default {true}
+   */
+  useRecordTypeValue?: boolean
 }
 
 export function dns (init: DNSInit = {}): DNS {

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,6 +213,9 @@ export interface QueryOptions extends ProgressOptions<ResolveDnsProgressEvents> 
   /**
    * Whether to use the value or string label of the record type
    *
+   * Note that for DNS-over-HTTPS, this is always `false` because the npm package
+   * `dns-packet` only supports string label record types for the `encode` method.
+   *
    * @default {true}
    */
   useRecordTypeValue?: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,9 +213,6 @@ export interface QueryOptions extends ProgressOptions<ResolveDnsProgressEvents> 
   /**
    * Whether to use the value or string label of the record type when passing queries to the resolver
    *
-   * Note that for DNS-over-HTTPS, this is always `false` because the npm package
-   * `dns-packet` only supports string label record types for the `encode` method.
-   *
    * @default {true}
    */
   useRecordTypeValue?: boolean

--- a/src/resolvers/default.ts
+++ b/src/resolvers/default.ts
@@ -16,7 +16,7 @@ const nodeResolver: DNSResolver = async (fqdn, options = {}) => {
     options.signal?.addEventListener('abort', listener)
 
     const answers = await Promise.all(types.map(async type => {
-      const valueType = convertType(type, options.useRecordTypeValue)
+      const valueType = convertType(type, true)
       if (valueType === RecordType.A) {
         return mapToAnswers(fqdn, type, await resolver.resolve4(fqdn))
       }

--- a/src/resolvers/dns-json-over-https.ts
+++ b/src/resolvers/dns-json-over-https.ts
@@ -42,7 +42,7 @@ export function dnsJsonOverHttps (url: string, init: DNSJSONOverHTTPSOptions = {
     const searchParams = new URLSearchParams()
     searchParams.set('name', fqdn)
 
-    getTypes(options.types).forEach(type => {
+    getTypes(options.types, options.useRecordTypeValue).forEach(type => {
       searchParams.append('type', type.toString())
     })
 

--- a/src/resolvers/dns-json-over-https.ts
+++ b/src/resolvers/dns-json-over-https.ts
@@ -41,8 +41,9 @@ export function dnsJsonOverHttps (url: string, init: DNSJSONOverHTTPSOptions = {
   return async (fqdn, options = {}) => {
     const searchParams = new URLSearchParams()
     searchParams.set('name', fqdn)
+    const useRecordTypeValue = options.useRecordTypeValue ?? true
 
-    getTypes(options.types, options.useRecordTypeValue).forEach(type => {
+    getTypes(options.types, useRecordTypeValue).forEach(type => {
       searchParams.append('type', type.toString())
     })
 
@@ -61,7 +62,7 @@ export function dnsJsonOverHttps (url: string, init: DNSJSONOverHTTPSOptions = {
         throw new Error(`Unexpected HTTP status: ${res.status} - ${res.statusText}`)
       }
 
-      const response = toDNSResponse(await res.json())
+      const response = toDNSResponse(await res.json(), useRecordTypeValue)
 
       options.onProgress?.(new CustomProgressEvent<DNSResponse>('dns:response', { detail: response }))
 

--- a/src/resolvers/dns-over-https.ts
+++ b/src/resolvers/dns-over-https.ts
@@ -40,7 +40,8 @@ export function dnsOverHttps (url: string, init: DNSOverHTTPSOptions = {}): DNSR
   })
 
   return async (fqdn, options = {}) => {
-    const types = getTypes(options.types, false) // always use RecordTypeLabel for DNS-over-HTTPS
+    const useRecordTypeValue = options.useRecordTypeValue ?? true
+    const types = getTypes(options.types, false) // always use RecordTypeLabel for dnsPacket
 
     const dnsQuery = dnsPacket.encode({
       type: 'query',
@@ -71,7 +72,7 @@ export function dnsOverHttps (url: string, init: DNSOverHTTPSOptions = {}): DNSR
       }
 
       const buf = await res.arrayBuffer()
-      const response = toDNSResponse(dnsPacket.decode(Buffer.from(buf)))
+      const response = toDNSResponse(dnsPacket.decode(Buffer.from(buf)), useRecordTypeValue)
 
       options.onProgress?.(new CustomProgressEvent<DNSResponse>('dns:response', { detail: response }))
 

--- a/src/resolvers/dns-over-https.ts
+++ b/src/resolvers/dns-over-https.ts
@@ -5,7 +5,6 @@ import dnsPacket from 'dns-packet'
 import PQueue from 'p-queue'
 import { CustomProgressEvent } from 'progress-events'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
-import { RecordType } from '../index.js'
 import { getTypes } from '../utils/get-types.js'
 import { toDNSResponse } from '../utils/to-dns-response.js'
 import type { DNSResolver } from './index.js'
@@ -20,26 +19,6 @@ export const DEFAULT_QUERY_CONCURRENCY = 4
 
 export interface DNSOverHTTPSOptions {
   queryConcurrency?: number
-}
-
-function toType (type: RecordType): 'A' | 'AAAA' | 'TXT' | 'CNAME' {
-  if (type === RecordType.A) {
-    return 'A'
-  }
-
-  if (type === RecordType.AAAA) {
-    return 'AAAA'
-  }
-
-  if (type === RecordType.TXT) {
-    return 'TXT'
-  }
-
-  if (type === RecordType.CNAME) {
-    return 'CNAME'
-  }
-
-  throw new Error('Unsupported DNS record type')
 }
 
 /**
@@ -61,14 +40,14 @@ export function dnsOverHttps (url: string, init: DNSOverHTTPSOptions = {}): DNSR
   })
 
   return async (fqdn, options = {}) => {
-    const types = getTypes(options.types)
+    const types = getTypes(options.types, false) // always use RecordTypeLabel for DNS-over-HTTPS
 
     const dnsQuery = dnsPacket.encode({
       type: 'query',
       id: 0,
       flags: dnsPacket.RECURSION_DESIRED,
       questions: types.map(type => ({
-        type: toType(type),
+        type,
         name: fqdn
       }))
     })

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,7 +1,7 @@
 import hashlru from 'hashlru'
 import { RecordType } from '../index.js'
 import { DEFAULT_TTL, toDNSResponse } from './to-dns-response.js'
-import type { Answer, DNSResponse } from '../index.js'
+import type { Answer, DNSResponse, RecordTypeLabel } from '../index.js'
 
 interface CachedAnswer {
   expires: number
@@ -9,7 +9,7 @@ interface CachedAnswer {
 }
 
 export interface AnswerCache {
-  get (fqdn: string, types: RecordType[]): DNSResponse | undefined
+  get (fqdn: string, types: Array<RecordType | RecordTypeLabel>): DNSResponse | undefined
   add (domain: string, answer: Answer): void
   remove (domain: string, type: ResponseType): void
   clear (): void

--- a/src/utils/get-types.ts
+++ b/src/utils/get-types.ts
@@ -1,9 +1,43 @@
-import { RecordType } from '../index.js'
+import { RecordType, RecordTypeLabel } from '../index.js'
 
-export function getTypes (types?: RecordType | RecordType[]): RecordType[] {
+function recordTypeGuard (type: RecordType | RecordTypeLabel): type is RecordType {
+  return typeof type === 'number' && type in RecordType
+}
+function recordTypeLabelGuard (type: RecordType | RecordTypeLabel): type is RecordTypeLabel {
+  return typeof type === 'string' && type in RecordTypeLabel
+}
+
+export function convertType (type: RecordType | RecordTypeLabel, useRecordTypeValue?: true): RecordType
+export function convertType (type: RecordType | RecordTypeLabel, useRecordTypeValue?: false): RecordTypeLabel
+export function convertType (type: RecordType | RecordTypeLabel, useRecordTypeValue?: boolean): RecordType | RecordTypeLabel
+export function convertType (type: RecordType | RecordTypeLabel, useRecordTypeValue: boolean = true): RecordType | RecordTypeLabel {
+  if (useRecordTypeValue && recordTypeGuard(type)) {
+    return type
+  } else if (!useRecordTypeValue && recordTypeLabelGuard(type)) {
+    return type
+  } else {
+    const reverseMap = {
+      [RecordTypeLabel.A]: RecordType.A,
+      [RecordType.A]: RecordTypeLabel.A,
+      [RecordTypeLabel.CNAME]: RecordType.CNAME,
+      [RecordType.CNAME]: RecordTypeLabel.CNAME,
+      [RecordTypeLabel.TXT]: RecordType.TXT,
+      [RecordType.TXT]: RecordTypeLabel.TXT,
+      [RecordTypeLabel.AAAA]: RecordType.AAAA,
+      [RecordType.AAAA]: RecordTypeLabel.AAAA
+    }
+    // convert given type to other
+    return reverseMap[type]
+  }
+}
+
+export function getTypes (types?: (RecordType | RecordTypeLabel) | Array<RecordType | RecordTypeLabel>, useRecordTypeValue?: true): RecordType[]
+export function getTypes (types?: (RecordType | RecordTypeLabel) | Array<RecordType | RecordTypeLabel>, useRecordTypeValue?: false): RecordTypeLabel[]
+export function getTypes (types?: (RecordType | RecordTypeLabel) | Array<RecordType | RecordTypeLabel>, useRecordTypeValue?: boolean): Array<RecordType | RecordTypeLabel>
+export function getTypes (types?: (RecordType | RecordTypeLabel) | Array<RecordType | RecordTypeLabel>, useRecordTypeValue: boolean = true): Array<RecordType | RecordTypeLabel> {
   const DEFAULT_TYPES = [
     RecordType.A
-  ]
+  ].map(type => convertType(type, useRecordTypeValue))
 
   if (types == null) {
     return DEFAULT_TYPES
@@ -14,10 +48,10 @@ export function getTypes (types?: RecordType | RecordType[]): RecordType[] {
       return DEFAULT_TYPES
     }
 
-    return types
+    return types.map(type => convertType(type, useRecordTypeValue))
   }
 
   return [
-    types
+    convertType(types, useRecordTypeValue)
   ]
 }

--- a/src/utils/get-types.ts
+++ b/src/utils/get-types.ts
@@ -26,8 +26,11 @@ export function convertType (type: RecordType | RecordTypeLabel, useRecordTypeVa
       [RecordTypeLabel.AAAA]: RecordType.AAAA,
       [RecordType.AAAA]: RecordTypeLabel.AAAA
     }
-    // convert given type to other
-    return reverseMap[type]
+    const value = reverseMap[type]
+    if (value == null) {
+      throw new Error(`Unsupported DNS record type ${type}`)
+    }
+    return value
   }
 }
 

--- a/src/utils/to-dns-response.ts
+++ b/src/utils/to-dns-response.ts
@@ -1,12 +1,13 @@
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { RecordType, type DNSResponse } from '../index.js'
+import { convertType } from './get-types.js'
 
 /**
  * This TTL will be used if the remote service does not return one
  */
 export const DEFAULT_TTL = 60
 
-export function toDNSResponse (obj: any): DNSResponse {
+export function toDNSResponse (obj: any, useRecordTypeValue: boolean = true): DNSResponse {
   return {
     Status: obj.Status ?? 0,
     TC: obj.TC ?? obj.flag_tc ?? false,
@@ -23,7 +24,7 @@ export function toDNSResponse (obj: any): DNSResponse {
     Answer: (obj.Answer ?? obj.answers ?? []).map((answer: any) => {
       return {
         name: answer.name,
-        type: RecordType[answer.type],
+        type: convertType(answer.type, useRecordTypeValue),
         TTL: (answer.TTL ?? answer.ttl ?? DEFAULT_TTL),
         data: answer.data instanceof Uint8Array ? uint8ArrayToString(answer.data) : answer.data
       }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'aegir/chai'
 import Sinon from 'sinon'
-import { RecordType, dns } from '../src/index.js'
+import { RecordType, RecordTypeLabel, dns } from '../src/index.js'
 import type { Answer } from '../src/index.js'
 
 describe('dns', () => {
@@ -234,5 +234,56 @@ describe('dns', () => {
 
     // only one resolver should have been called
     expect(resolvers.reduce((acc, curr) => acc + curr.callCount, 0)).to.equal(1)
+  })
+
+  it('should convert RecordTypeLabel to RecordType when useRecordTypeValue=true', async () => {
+    const defaultResolver = Sinon.stub()
+
+    const answerA = {
+      name: 'example-useRecordTypeValue-true.com',
+      data: '123.123.123.123',
+      type: RecordTypeLabel.A
+    }
+
+    defaultResolver.withArgs('example-useRecordTypeValue-true.com').resolves({
+      Answer: [answerA]
+    })
+
+    const resolver = dns({
+      resolvers: {
+        '.': defaultResolver
+      }
+    })
+
+    const res1 = await resolver.query('example-useRecordTypeValue-true.com')
+    expect(res1).to.have.nested.property('Answer[0].type', RecordType.A)
+
+    expect(defaultResolver.callCount).to.equal(1)
+  })
+
+  it('should convert RecordType to RecordTypeLabel when useRecordTypeValue=false', async () => {
+    const defaultResolver = Sinon.stub()
+
+    const answerA = {
+      name: 'example-useRecordTypeValue-false.com',
+      data: '123.123.123.123',
+      type: RecordType.A
+    }
+
+    defaultResolver.withArgs('example-useRecordTypeValue-false.com').resolves({
+      Answer: [answerA]
+    })
+
+    const resolver = dns({
+      resolvers: {
+        '.': defaultResolver
+      },
+      useRecordTypeValue: false
+    })
+
+    const res1 = await resolver.query('example-useRecordTypeValue-false.com')
+    expect(res1).to.have.nested.property('Answer[0].type', RecordTypeLabel.A)
+
+    expect(defaultResolver.callCount).to.equal(1)
   })
 })

--- a/test/resolvers/dns-json-over-https.spec.ts
+++ b/test/resolvers/dns-json-over-https.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'aegir/chai'
-import { RecordType } from '../../src/index.js'
+import { RecordType, RecordTypeLabel } from '../../src/index.js'
 import { dnsJsonOverHttps } from '../../src/resolvers/dns-json-over-https.js'
 
 describe('dns-json-over-https', () => {
@@ -10,5 +10,38 @@ describe('dns-json-over-https', () => {
     })
 
     expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
+    expect(result).to.have.nested.property('Answer[0].type', RecordType.A)
+  })
+
+  it('should query dns with RecordTypeLabel', async () => {
+    const resolver = dnsJsonOverHttps('https://cloudflare-dns.com/dns-query')
+    const result = await resolver('google.com', {
+      types: [RecordTypeLabel.A]
+    })
+
+    expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
+    expect(result).to.have.nested.property('Answer[0].type', RecordType.A)
+  })
+
+  it('should query dns with useRecordTypeValue=false', async () => {
+    const resolver = dnsJsonOverHttps('https://cloudflare-dns.com/dns-query')
+    const result = await resolver('google.com', {
+      types: [RecordType.A],
+      useRecordTypeValue: false
+    })
+
+    expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
+    expect(result).to.have.nested.property('Answer[0].type', RecordTypeLabel.A)
+  })
+
+  it('should query dns with RecordTypeLabel & useRecordTypeValue=false', async () => {
+    const resolver = dnsJsonOverHttps('https://cloudflare-dns.com/dns-query')
+    const result = await resolver('google.com', {
+      types: [RecordTypeLabel.A],
+      useRecordTypeValue: false
+    })
+
+    expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
+    expect(result).to.have.nested.property('Answer[0].type', RecordTypeLabel.A)
   })
 })

--- a/test/resolvers/dns-over-https.spec.ts
+++ b/test/resolvers/dns-over-https.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'aegir/chai'
-import { RecordType } from '../../src/index.js'
+import { RecordType, RecordTypeLabel } from '../../src/index.js'
 import { dnsOverHttps } from '../../src/resolvers/dns-over-https.js'
 
 describe('dns-over-https', () => {
@@ -10,5 +10,38 @@ describe('dns-over-https', () => {
     })
 
     expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
+    expect(result).to.have.nested.property('Answer[0].type', RecordType.A)
+  })
+
+  it('should query dns with RecordTypeLabel', async () => {
+    const resolver = dnsOverHttps('https://cloudflare-dns.com/dns-query')
+    const result = await resolver('google.com', {
+      types: [RecordTypeLabel.A]
+    })
+
+    expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
+    expect(result).to.have.nested.property('Answer[0].type', RecordType.A)
+  })
+
+  it('should query dns with useRecordTypeValue=false', async () => {
+    const resolver = dnsOverHttps('https://cloudflare-dns.com/dns-query')
+    const result = await resolver('google.com', {
+      types: [RecordType.A],
+      useRecordTypeValue: false
+    })
+
+    expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
+    expect(result).to.have.nested.property('Answer[0].type', RecordTypeLabel.A)
+  })
+
+  it('should query dns with RecordTypeLabel & useRecordTypeValue=false', async () => {
+    const resolver = dnsOverHttps('https://cloudflare-dns.com/dns-query')
+    const result = await resolver('google.com', {
+      types: [RecordTypeLabel.A],
+      useRecordTypeValue: false
+    })
+
+    expect(result).to.have.nested.property('Answer[0].data').that.is.a('string')
+    expect(result).to.have.nested.property('Answer[0].type', RecordTypeLabel.A)
   })
 })


### PR DESCRIPTION
- feat: support records as numeric or string label
- chore: remove unnecessary toType method
- test: add basic useRecordTypeValue tests
- fix: cache key uses RecordType only

This helps enable users to resolve the issues brought up in https://github.com/ipfs/helia/issues/474 and https://github.com/ipfs-shipyard/helia-service-worker-gateway/issues/130
