### PR TITLE
fix: use string enum for RecordType [WIP]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,10 +90,10 @@ import type { ProgressEvent, ProgressOptions } from 'progress-events'
  * @see https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4.
  */
 export enum RecordType {
-  A = 1,
-  CNAME = 5,
-  TXT = 16,
-  AAAA = 28
+  A = 'A',
+  CNAME = 'CNAME',
+  TXT = 'TXT',
+  AAAA = 'AAAA'
 }
 
 export interface Question {


### PR DESCRIPTION
Supposed to be a replacement for https://github.com/multiformats/js-dns/pull/5 to satisfy https://github.com/multiformats/js-dns/pull/5#issuecomment-2033990839
