### PR TITLE
fix: move dns-packet types to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,6 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "@types/dns-packet": "^5.6.5",
     "buffer": "^6.0.3",
     "dns-packet": "^5.6.1",
     "hashlru": "^2.3.0",
@@ -167,6 +166,7 @@
     "uint8arrays": "^5.0.2"
   },
   "devDependencies": {
+    "@types/dns-packet": "^5.6.5",
     "@types/sinon": "^17.0.2",
     "aegir": "^47.0.21",
     "sinon": "^18.0.0"


### PR DESCRIPTION
Types should not be production dependencies.