### PR TITLE
fix: replace dns-packet with `@dnsquery/dns-packet`

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,6 @@
+/** @type {import('aegir').PartialOptions} */
+export default {
+  build: {
+    bundlesizeMax: '12KB'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -158,8 +158,7 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "buffer": "^6.0.3",
-    "dns-packet": "^5.6.1",
+    "@dnsquery/dns-packet": "^6.1.1",
     "hashlru": "^2.3.0",
     "p-queue": "^9.0.0",
     "progress-events": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   "scripts": {
     "clean": "aegir clean",
     "lint": "aegir lint",
-    "dep-check": "aegir dep-check -i buffer",
+    "dep-check": "aegir dep-check",
     "build": "aegir build",
     "test": "aegir test -f",
     "test:chrome": "aegir test -t browser --cov",

--- a/src/resolvers/dns-over-https.ts
+++ b/src/resolvers/dns-over-https.ts
@@ -1,6 +1,5 @@
 /* eslint-env browser */
 
-import { Buffer } from 'buffer'
 import { decode, encode, RECURSION_DESIRED } from '@dnsquery/dns-packet'
 import PQueue from 'p-queue'
 import { CustomProgressEvent } from 'progress-events'

--- a/src/resolvers/dns-over-https.ts
+++ b/src/resolvers/dns-over-https.ts
@@ -1,7 +1,7 @@
 /* eslint-env browser */
 
 import { Buffer } from 'buffer'
-import dnsPacket from 'dns-packet'
+import { decode, encode, RECURSION_DESIRED } from '@dnsquery/dns-packet'
 import PQueue from 'p-queue'
 import { CustomProgressEvent } from 'progress-events'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
@@ -63,10 +63,10 @@ export function dnsOverHttps (url: string, init: DNSOverHTTPSOptions = {}): DNSR
   return async (fqdn, options = {}) => {
     const types = getTypes(options.types)
 
-    const dnsQuery = dnsPacket.encode({
+    const dnsQuery = encode({
       type: 'query',
       id: 0,
-      flags: dnsPacket.RECURSION_DESIRED,
+      flags: RECURSION_DESIRED,
       questions: types.map(type => ({
         type: toType(type),
         name: fqdn
@@ -92,7 +92,7 @@ export function dnsOverHttps (url: string, init: DNSOverHTTPSOptions = {}): DNSR
       }
 
       const buf = await res.arrayBuffer()
-      const response = toDNSResponse(dnsPacket.decode(Buffer.from(buf)))
+      const response = toDNSResponse(decode(Buffer.from(buf)))
 
       options.onProgress?.(new CustomProgressEvent<DNSResponse>('dns:response', response))
 

--- a/src/resolvers/dns-over-https.ts
+++ b/src/resolvers/dns-over-https.ts
@@ -91,7 +91,7 @@ export function dnsOverHttps (url: string, init: DNSOverHTTPSOptions = {}): DNSR
       }
 
       const buf = await res.arrayBuffer()
-      const response = toDNSResponse(decode(Buffer.from(buf)))
+      const response = toDNSResponse(decode(new Uint8Array(buf, 0, buf.byteLength)))
 
       options.onProgress?.(new CustomProgressEvent<DNSResponse>('dns:response', response))
 


### PR DESCRIPTION
It is an ESM port that removes the buffer dependency so results in smaller bundle sizes.