### PR TITLE
fix: try other resovlers when answers are empty

### DIFF
--- a/src/dns.ts
+++ b/src/dns.ts
@@ -1,24 +1,27 @@
 import { CustomProgressEvent } from 'progress-events'
-import { DNSQueryFailedError } from './errors.ts'
+import { DNSQueryFailedError, EmptyDNSAnswerError } from './errors.ts'
 import { defaultResolver } from './resolvers/default.ts'
 import { cache } from './utils/cache.ts'
 import { getTypes } from './utils/get-types.ts'
-import type { DNS as DNSInterface, DNSInit, DNSResponse, QueryOptions } from './index.ts'
+import type { DNS as DNSInterface, DNSInit, DNSResponse, QueryOptions, DNSResolverSorter } from './index.ts'
 import type { DNSResolver } from './resolvers/index.ts'
 import type { AnswerCache } from './utils/cache.ts'
 import type { ComponentLogger } from '@libp2p/interface'
 
 const DEFAULT_ANSWER_CACHE_SIZE = 1000
+const RANDOM: DNSResolverSorter = () => (Math.random() > 0.5) ? -1 : 1
 
 export class DNS implements DNSInterface {
   private readonly resolvers: Record<string, DNSResolver[]>
   private readonly cache: AnswerCache
   private readonly logger?: ComponentLogger
+  private readonly sorter: DNSResolverSorter
 
   constructor (init: DNSInit) {
     this.resolvers = {}
     this.cache = cache(init.cacheSize ?? DEFAULT_ANSWER_CACHE_SIZE)
     this.logger = init.logger
+    this.sorter = init.sorter ?? RANDOM
 
     Object.entries(init.resolvers ?? {}).forEach(([tld, resolver]) => {
       if (!Array.isArray(resolver)) {
@@ -58,9 +61,7 @@ export class DNS implements DNSInterface {
     }
 
     const tld = `${domain.split('.').pop()}.`
-    const resolvers = (this.resolvers[tld] ?? this.resolvers['.']).sort(() => {
-      return (Math.random() > 0.5) ? -1 : 1
-    })
+    const resolvers = (this.resolvers[tld] ?? this.resolvers['.']).sort(this.sorter)
 
     const errors: Error[] = []
 
@@ -76,6 +77,10 @@ export class DNS implements DNSInterface {
           logger: this.logger,
           types
         })
+
+        if (result.Answer.length === 0) {
+          throw new EmptyDNSAnswerError('Query result had no answers')
+        }
 
         for (const answer of result.Answer) {
           this.cache.add(domain, answer)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,3 +2,8 @@ export class DNSQueryFailedError extends AggregateError {
   static name = 'DNSQueryFailedError'
   name = 'DNSQueryFailedError'
 }
+
+export class EmptyDNSAnswerError extends AggregateError {
+  static name = 'EmptyDNSAnswerError'
+  name = 'EmptyDNSAnswerError'
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,10 @@ export interface DNSResponse {
  */
 export const MAX_RECURSIVE_DEPTH = 32
 
+export interface DNSResolverSorter {
+  (a: DNSResolver, b: DNSResolver): -1 | 0 | 1
+}
+
 export interface QueryOptions extends ProgressOptions<ResolveDnsProgressEvents> {
   signal?: AbortSignal
 
@@ -266,6 +270,13 @@ export interface DNSInit {
    * An optional logger
    */
   logger?: ComponentLogger
+
+  /**
+   * Sort resolvers before invoking them
+   *
+   * @default random
+   */
+  sorter?: DNSResolverSorter
 }
 
 export function dns (init: DNSInit = {}): DNS {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -238,4 +238,43 @@ describe('dns', () => {
     // only one resolver should have been called
     expect(resolvers.reduce((acc, curr) => acc + curr.callCount, 0)).to.equal(1)
   })
+
+  it('should return result when some resolvers fail and some succeed', async () => {
+    const goodResolver = Sinon.stub()
+    const badResolver = Sinon.stub()
+    const reallyBadResolver = Sinon.stub()
+
+    const answer = {
+      name: 'example.com',
+      data: '123.123.123.123',
+      type: RecordType.A
+    }
+
+    goodResolver.withArgs('example.com').resolves({
+      Answer: [answer]
+    })
+
+    badResolver.withArgs('example.com').resolves({
+      Answer: []
+    })
+
+    reallyBadResolver.withArgs('example.com').rejects(new Error('Urk!'))
+
+    const resolver = dns({
+      resolvers: {
+        '.': [
+          badResolver,
+          reallyBadResolver,
+          goodResolver
+        ]
+      },
+      sorter: () => 0
+    })
+    const result = await resolver.query('example.com')
+
+    expect(result).to.have.nested.property('Answer[0].data', answer.data)
+    expect(badResolver.called).to.be.true('Bad resolver was not invoked')
+    expect(reallyBadResolver.called).to.be.true('Really bad resolver was not invoked')
+    expect(goodResolver.called).to.be.true('Good resolver was not invoked')
+  })
 })


### PR DESCRIPTION
If a resolver returns an empty answer array, try other resolvers until we either run out of resolvers or an answer is found.